### PR TITLE
replace log4j:1.2 by reload4j:1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <maven.version>2.2.1</maven.version>
         <swagger.version>1.5.21</swagger.version>
         <jackson.version>2.8.9</jackson.version>
-        <log4j.version>1.2.16</log4j.version>
+        <reload4j.version>1.2.20</reload4j.version>
         <handlebars.version>1.3.2</handlebars.version>
         <commons-io.version>2.0.1</commons-io.version>
         <reflections.version>0.9.9</reflections.version>
@@ -172,9 +172,9 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>${reload4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
swagger-maven-plugin keeps gettings back log4j:1.2.16 in my local repo and breaches company security rules.